### PR TITLE
Use common parent pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
   <name>Bootstrap 4 API Plugin</name>
   <version>${revision}${changelist}</version>
 
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+
   <description>Jenkins plug-in that provides Bootstrap 4.</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>2.0.0-beta-2</version>
+    <version>2.0.0</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>3.55</version>
-    <relativePath />
+    <groupId>org.jvnet.hudson.plugins</groupId>
+    <artifactId>analysis-pom</artifactId>
+    <version>2.0.0-beta-2</version>
+    <relativePath/>
   </parent>
 
   <artifactId>bootstrap4-api</artifactId>
@@ -13,62 +13,22 @@
   <packaging>hpi</packaging>
   <name>Bootstrap 4 API Plugin</name>
   <version>${revision}${changelist}</version>
+
   <description>Jenkins plug-in that provides Bootstrap 4.</description>
-  <url>https://github.com/jenkinsci/bootstrap4-api-plugin</url>
 
   <properties>
     <revision>4.4.1-5-beta1</revision>
     <changelist>-SNAPSHOT</changelist>
     <bootstrap.version>4.4.1</bootstrap.version>
 
+    <module.name>${project.groupId}.bootstrap4</module.name>
+
     <jquery3-api.version>3.4.1-3-beta1</jquery3-api.version>
     <popper-api.version>1.15.0-2-beta1</popper-api.version>
     <font-awesome-api.version>5.12.0-1-beta1</font-awesome-api.version>
 
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jenkins.version>2.138.4</jenkins.version>
-    <java.level>8</java.level>
-    <jenkins-test-harness.version>2.59</jenkins-test-harness.version>
-    <spotbugs.failOnError>false</spotbugs.failOnError>
-    <slf4j.version>1.7.30</slf4j.version>
-    <codingstyle.version>0.3.2</codingstyle.version>
-
-    <module.name>${project.groupId}.bootstrap4</module.name>
-
-    <!-- Library Dependencies Versions -->
-    <error-prone.version>2.3.3</error-prone.version>
-    <spotbugs.annotations>3.1.12</spotbugs.annotations>
     <commons.lang.version>3.9</commons.lang.version>
-    <slf4j.version>1.7.30</slf4j.version>
 
-    <!-- Test Library Dependencies Versions -->
-    <junit.version>5.5.2</junit.version>
-    <junit-platform-launcher.version>1.5.2</junit-platform-launcher.version>
-    <mockito.version>3.2.4</mockito.version>
-    <assertj.version>3.14.0</assertj.version>
-    <archunit.version>0.13.0</archunit.version>
-
-    <!-- Maven plug-in versions -->
-    <maven-pmd-plugin.version>3.12.0</maven-pmd-plugin.version>
-    <pmd.version>6.20.0</pmd.version>
-    <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
-    <checkstyle.version>8.28</checkstyle.version>
-    <spotbugs-maven-plugin.version>3.1.12.2</spotbugs-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-    <maven-surefire.plugin>3.0.0-M4</maven-surefire.plugin>
-    <maven-failsafe.plugin>3.0.0-M4</maven-failsafe.plugin>
-    <jar.maven.plugin>3.0.2</jar.maven.plugin>
-    <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
-    <depgraph-maven-plugin.version>3.3.0</depgraph-maven-plugin.version>
-    <animal-sniffer-maven-plugin.version>1.18</animal-sniffer-maven-plugin.version>
-    <maven-hpi-plugin.version>2.5</maven-hpi-plugin.version>
-    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-    <pitest-maven.plugin>1.4.11</pitest-maven.plugin>
-    <pitest-maven.junit5.plugin>0.11</pitest-maven.junit5.plugin>
-    <revapi-maven-plugin.version>0.11.1</revapi-maven-plugin.version>
-    <revapi-java.version>0.19.1</revapi-java.version>
-    <assertj-assertions-generator-maven-plugin.version>2.2.0</assertj-assertions-generator-maven-plugin.version>
   </properties>
 
   <licenses>
@@ -85,16 +45,6 @@
       <email>ullrich.hafner@gmail.com</email>
     </developer>
   </developers>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -119,74 +69,6 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>font-awesome-api</artifactId>
       <version>${font-awesome-api.version}</version>
-    </dependency>
-
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <version>${junit-platform-launcher.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>${assertj.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-api</artifactId>
-      <version>${archunit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-engine</artifactId>
-      <version>${archunit.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>junit-platform-engine</artifactId>
-          <groupId>org.junit.platform</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <name>Bootstrap 4 API Plugin</name>
   <version>${revision}${changelist}</version>
 
-  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <url>https://github.com/jenkinsci/bootstrap4-api-plugin</url>
 
   <description>Jenkins plug-in that provides Bootstrap 4.</description>
 


### PR DESCRIPTION
Push configuration of static analysis tools and all common test dependencies into a new [parent pom](https://github.com/jenkinsci/analysis-pom-plugin).