### PR TITLE
Remove reference to removed CSS file

### DIFF
--- a/src/main/resources/io/jenkins/plugins/bootstrap4.jelly
+++ b/src/main/resources/io/jenkins/plugins/bootstrap4.jelly
@@ -12,7 +12,6 @@ Use it like <st:adjunct includes="io.jenkins.plugins.bootstrap4"/>
 
   <link type="text/css" rel="stylesheet" href="${resURL}/plugin/bootstrap4-api/css/bootstrap.min.css"/>
   <link type="text/css" rel="stylesheet" href="${resURL}/plugin/bootstrap4-api/css/jenkins-style.css"/>
-  <link type="text/css" rel="stylesheet" href="${resURL}/css/style.css"/>
 
   <script type="text/javascript" src="${resURL}/plugin/bootstrap4-api/js/bootstrap.min.js"/>
   <script type="text/javascript" src="${resURL}/plugin/bootstrap4-api/js/no-prototype.js"/>


### PR DESCRIPTION
Seems to be loaded through https://github.com/jenkinsci/bootstrap4-api-plugin/blob/master/src/main/resources/bootstrap/layout-pre-2.222.jelly#L108 for older Jenkinses. For new ones this plugin currently loads both the new styles and the old, causing some minor UI defects.

Relates to https://github.com/jenkinsci/jenkins/pull/4585