### PR TITLE
Improves version detection to handle more edge cases

### DIFF
--- a/src/main/resources/bootstrap/layout.jelly
+++ b/src/main/resources/bootstrap/layout.jelly
@@ -59,16 +59,17 @@ THE SOFTWARE.
   <j:new var="h" className="hudson.Functions" /><!-- instead of JSP functions -->
   ${h.initPageVariables(context)}
 
-  <j:set var="versionParts" value="${h.version.split('\.',3)}" />
+  <j:set var="versionParts" value="${h.version.split('\.')}" />
   <j:set var="majorVersion" value="${versionParts[0]}" />
-  <j:set var="minorVersion" value="${versionParts[1].replace('-SNAPSHOT', '')}" />
+  <j:set var="rawMinorVersion" value="${versionParts[1].split('-')}" />
+  <j:set var="minorVersion" value="${rawMinorVersion[0]}" />
   <j:choose>
-    <j:when test="${(majorVersion > 1 and minorVersion > 234) or majorVersion > 2}">
+    <j:when test="${(majorVersion ge 2 and minorVersion ge 235) or majorVersion > 2}">
       <l:layout title="${title}" permission="${permission}" type="${type}" nogrid="true">
         <d:invokeBody/>
       </l:layout>
     </j:when>
-    <j:when test="${majorVersion > 2 or minorVersion > 221}">
+    <j:when test="${minorVersion ge 222}">
       <bs:layout-post-2.222 title="${title}" permission="${permission}" type="${type}">
         <d:invokeBody/>
       </bs:layout-post-2.222>


### PR DESCRIPTION
It now detects cases like incremental versions.

I tried doing it properly on an unit tested class but I cannot get Stapler to load it (this branch https://github.com/fqueiruga/bootstrap4-api-plugin/tree/improve-version-detection-with-java-class), that's why I ended up just modifying the jelly code.