### PR TITLE
Exclude transitive `org.webjars:popper.js` dependency from tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,19 @@
       <artifactId>bootstrap</artifactId>
       <version>${bootstrap.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.webjars</groupId>
+          <artifactId>popper.js</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- WebJars Dependencies - bundled as API plugins -->
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>popper-api</artifactId>
+      <artifactId>popper2-api</artifactId>
+      <version>2.11.5-1</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
       <artifactId>bootstrap</artifactId>
       <version>${bootstrap.version}</version>
       <scope>provided</scope>
+      <!-- Provided by popper-api plugin -->
       <exclusions>
         <exclusion>
           <groupId>org.webjars</groupId>
@@ -67,8 +68,7 @@
     <!-- WebJars Dependencies - bundled as API plugins -->
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>popper2-api</artifactId>
-      <version>2.11.5-1</version>
+      <artifactId>popper-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
This dependency is handled by our plugin-to-plugin dependency on `popper-api`.